### PR TITLE
Avoid deploying full certificate bundle

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -61,15 +61,4 @@ letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
       - file: /usr/local/bin/renew_letsencrypt_cert.sh
 
-create-fullchain-privkey-pem-for-{{ domainlist[0] }}:
-  cmd.run:
-    - name: |
-        cat /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain.pem \
-            /etc/letsencrypt/live/{{ domainlist[0] }}/privkey.pem \
-            > /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem && \
-        chmod 600 /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem
-    - creates: /etc/letsencrypt/live/{{ domainlist[0] }}/fullchain-privkey.pem
-    - require:
-      - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
-
 {% endfor %}


### PR DESCRIPTION
We don't use this, so I would rather not deploy it.

Related reading: https://github.com/saltstack-formulas/letsencrypt-formula/issues/65