### PR TITLE
Allow the user to customise the cron schedule

### DIFF
--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -2,3 +2,7 @@
 # vim: ft=yaml
 letsencrypt:
   cli_install_dir: /opt/letsencrypt
+  cron:
+    minute: random
+    hour: random
+    dayweek: '*'

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -53,9 +53,9 @@ letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
   cron.present:
     - name: /usr/local/bin/renew_letsencrypt_cert.sh {{ domainlist|join(' ') }}
     - month: '*'
-    - minute: random
-    - hour: random
-    - dayweek: '*'
+    - minute: '{{ letsencrypt.cron.minute }}'
+    - hour: '{{ letsencrypt.cron.hour }}'
+    - dayweek: '{{  letsencrypt.cron.dayweek }}'
     - identifier: letsencrypt-{{ setname }}-{{ domainlist[0] }}
     - require:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}

--- a/pillar.example
+++ b/pillar.example
@@ -16,4 +16,7 @@ letsencrypt:
       - mail.example.com
     intranet:
       - intranet.example.com
-
+  cron:
+    minute: 10
+    hour: 2
+    dayweek: 1


### PR DESCRIPTION
Cherry-picked from https://github.com/saltstack-formulas/letsencrypt-formula/commit/6faa89fe4aaa92a1c8e4a13c99885191015f2768. This will allow us to set a custom schedule to renew Let's Encrypt certificates (eg. weekly instead of daily) to reduce the chances of us hitting their rate limits, which is an issue I ran into not so long ago.